### PR TITLE
Add GitHub Actions for package publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm test
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ The server exposes `POST /apply-patch` expecting form-data with fields:
 
 Provide the secret key in the `X-Secret-Key` header.
 
+## CI/CD
+
+This project uses GitHub Actions to run tests and publish the package to the
+GitHub Package Registry automatically. The workflow triggers on pushes to the
+`main` branch and ensures that the package is always built and released after
+tests succeed.
+

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "devDependencies": {
     "jest": "^29.7.0"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "bin": {
     "codex-local-bridge": "bin/codex-local-bridge.js"
   }


### PR DESCRIPTION
## Summary
- add publish workflow that runs only on main branch
- describe the CI/CD process in README
- configure npm publish registry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842480d8ab4832593977c5f2e6a25d5