### PR TITLE
Add automatic version bump in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,32 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: '22.x'
           registry-url: https://npm.pkg.github.com/
+
+      - name: Configure npm authentication
+        run: echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
       - run: npm ci
       - run: npm test
+
+      - name: Resolve version
+        run: |
+          set -x
+          PACKAGE=$(jq -r '.name' package.json)
+          VERGH=$(npm view "$PACKAGE" version --registry https://npm.pkg.github.com/ 2>/dev/null || true)
+          if [ -n "$VERGH" ]; then
+            VERGH=$(echo "$VERGH" | awk -F. -v OFS=. '{ $NF += 1; print }')
+          fi
+          VERLOC=$(jq -r '.version' package.json)
+          VEROUT=$(printf "%s\n%s\n" "$VERGH" "$VERLOC" | sed '/^$/d' | sort -V -r | head -n1)
+          jq -r '.version = "'${VEROUT}'"' package.json > /tmp/package.json
+          mv /tmp/package.json package.json
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN  }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary
- update Node.js version
- configure npm authentication for GitHub Packages
- add step to resolve version based on GitHub registry before publishing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684253e445288325abc675179e6a75f4