### PR TITLE
Add HEAD reset after patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,7 @@ curl -X POST http://localhost:3030/apply-patch \
 
 Replace `main` with the commit or branch to check out before applying the patch.
 
+After the patch has been processed, the repository is reset to `HEAD` so no
+changes remain in the working directory.
+
 


### PR DESCRIPTION
## Summary
- reset repository to `HEAD` after applying a patch to keep the working tree clean
- update README with note about the reset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842fea4585483258ad7ce0ec895a743